### PR TITLE
fix: Define varibale for PROMETHEUS_BASE_PATH in module level

### DIFF
--- a/charts/prometheus-optimizer/Chart.yaml
+++ b/charts/prometheus-optimizer/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prometheus-optimizer
 description: A Helm chart for prometheus-optimizer
 type: application
-version: 0.2.21
+version: 0.2.22
 appVersion: "1.0"

--- a/deployment/configmap.yaml
+++ b/deployment/configmap.yaml
@@ -11,6 +11,8 @@ data:
     prometheus_analysis:
       enabled: true
       address: "http://thanos-query-frontend.thanos.svc:9090"
+      # Specify custom base path for the Prometheus, default is empty ""
+      # base_path: "/prometheus"
     fetch_rules:
       enabled: true
       prometheus_discovery:

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -19,6 +19,8 @@ with open('config.yaml') as f:
     yaml_config = yaml.safe_load(f)
 rules_file_path = '/tmp/prometheus-rules'
 
+prometheus_base_path = os.getenv("PROMETHEUS_BASE_PATH", yaml_config['prometheus_analysis'].get('base_path', ''))
+
 
 def analyze_grafana_metrics():
     print("Analyzing Grafana")
@@ -48,8 +50,8 @@ def prometheus_pod_discovery(api_instance, namespace : str, labels : str) -> dic
                 })
 
 def lookup_prometheus_rules(prom_ip):
-    global PROMETHEUS_BASE_PATH
-    url = f"http://{prom_ip}:9090{PROMETHEUS_BASE_PATH}/api/v1/rules"
+    global prometheus_base_path
+    url = f"http://{prom_ip}:9090{prometheus_base_path}/api/v1/rules"
     print(f"Fetching Prometheus rules from {url}")  # Debugging log
     r = requests.get(url)
     r = r.json()
@@ -202,7 +204,6 @@ if __name__ == "__main__":
             print("Skipping, no rules found in pod.")
     if yaml_config['prometheus_analysis']['enabled']:
         PROMETHEUS_ADDRESS = yaml_config['prometheus_analysis']['address']
-        PROMETHEUS_BASE_PATH = os.getenv("PROMETHEUS_BASE_PATH", yaml_config['prometheus_analysis'].get('base_path', ''))
         analyze_prometheus_metrics()
     process_metrics_json()
     if yaml_config.get('mark_as_used_metric'):


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR adds a fix to undefined `PROMETHEUS_BASE_PATH` variable. Now the module includes an appropriate variable that handles the base path value for Prometheus. 
---
error stack trace:
```shell
Traceback (most recent call last):
  File “./optimizer.py”, line 196, in <module>
    rules = lookup_prometheus_rules(data.get(“pod_ip”))
  File “./optimizer.py”, line 52, in lookup_prometheus_rules
    url = f”http://{prom_ip}:9090{PROMETHEUS_BASE_PATH}/api/v1/rules”
NameError: name ‘PROMETHEUS_BASE_PATH’ is not defined
```